### PR TITLE
Remove unneeded request `android.hardware.ram.low`

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
 
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
-    <uses-feature android:name="android.hardware.ram.low" android:required="true" />
 
     <application
         android:allowBackup="false"


### PR DESCRIPTION
 * Remove uses-feature for `android.hardware.ram.low` as done for 0.45-legacy in https://gitlab.com/fdroid/fdroiddata/blob/master/metadata/com.github.yeriomin.yalpstore.yml . This removes a misleading incompatibility warning from fdroid and reading https://source.android.com/compatibility/9/android-9-cdd it is unclear what this feature declaration would mean